### PR TITLE
correct gbp.conf pristine-tar config

### DIFF
--- a/debian/gbp.conf
+++ b/debian/gbp.conf
@@ -1,5 +1,5 @@
 [DEFAULT]
-pristine-tar = True
+pristine-tar = False
 sign-tags = False
 
 [import-orig]


### PR DESCRIPTION
There is no pristine-tar branch, yet debian/gbp.conf configured to use
one. Running 'gbp' will thus fail, unless the configuration is
overridden by passing '--git-no-pristine-tar'

The gbp configuration should be corrected, as in this commit, or a
pristine-tar branch pushed. (the upstream git repo has such a branch)

Signed-off-by: Nick Brown <nickbroon@graphiant.com>